### PR TITLE
docs: refresh high-level docs and add a 109-task student catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,28 @@ Adjust your defaults accordingly:
 
 The point is depth of design thinking over process ceremony.
 
+## Documentation: audience and map
+
+The project documentation is written for a reader at the level of a **senior undergraduate
+in computer science** — someone who knows the observer pattern, singletons, and separation
+of concerns from coursework but has not seen this codebase. Keep that register when writing
+or updating docs: explain *why* a structure exists (in terms of those known concepts), not
+just what it is; prefer plain language plus a diagram over exhaustive API listings.
+
+| Doc | Role | Update when… |
+|-----|------|--------------|
+| [README.md](README.md) | Entry point: what the game is, the one-rule architecture summary, reading order | features, requirements, or the doc set change |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | The big idea, design vocabulary, event domains, run sequence, scene composition | domains, bridges, boot flow, or scene structure change |
+| [docs/EVENTS.md](docs/EVENTS.md) | Full event catalog (regenerable via `/list-events`) | any enum, auto-chain, or bridge mapping changes |
+| [docs/TRACKS.md](docs/TRACKS.md) | Track pipeline, ScriptableObject data model, geometry math | track data model, normalization, or selection logic changes |
+| [docs/ADDING_A_MECHANIC.md](docs/ADDING_A_MECHANIC.md) | Worked end-to-end walkthrough | the recommended workflow or skills change |
+| [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md) | Unity/environment caveats | a caveat is resolved or discovered |
+| [CLAUDE.md](CLAUDE.md) | AI-assistant rules: event-system enforcement, conventions, file reference | rules, conventions, or key paths change |
+| [docs/specs/](docs/specs/), [docs/playbooks/](docs/playbooks/) | Design specs / portable upgrade guides | historical records — generally append, don't rewrite |
+
+**Docs are part of the change.** A refactor that moves a seam (e.g. JSON → ScriptableObjects)
+isn't done until the docs above stop describing the old world.
+
 ## For forks and clones
 
 This guidance reflects the original author's working style. **If you have cloned or forked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ When adding any new feature or behavior, you MUST follow this workflow:
 | Events should auto-progress | `/add-auto-chain` after `/add-event` |
 | After any implementation work | `/audit-events` to verify compliance |
 | Before starting work on events | `/list-events` to understand current state |
-| Authoring track segments | Edit `TrackSegmentSO` / `TrackLevelSO` assets in the Inspector (see [docs/TRACKS.md](docs/TRACKS.md#authoring)). *The `/generate-segments` skill is legacy — it targets the removed JSON registry.* |
+| Authoring track segments | Edit `TrackSegmentSO` / `TrackLevelSO` assets in the Inspector, or use `/generate-segments` for bulk creation (see [docs/TRACKS.md](docs/TRACKS.md#authoring)) |
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ jumping, sliding, dashing, obstacles, coins, and power-ups — structured so tha
 communicates through a typed event bus rather than direct references. Use it as a starting
 point for your own runner, or as a reference for decoupled, event-driven Unity design.
 
+**Who this is for.** The template doubles as a teaching codebase. If you have taken a
+software-design or game-development course (senior-undergraduate level), you already know
+the ideas it is built from — publish/subscribe, the observer pattern, separation of
+concerns, and data-driven design. What this project shows is those ideas *applied at full
+scale*: an entire game where the only way systems talk to each other is by publishing and
+subscribing to named events.
+
+**Suggested reading order:**
+
+1. This README — what the game is and the shape of the architecture.
+2. [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — the big idea, the three event domains,
+   and how a run flows from boot to game over (with diagrams).
+3. [docs/EVENTS.md](docs/EVENTS.md) — the full event catalog; skim it to see the naming
+   pattern, then use it as a reference.
+4. [docs/TRACKS.md](docs/TRACKS.md) — how the endless track is generated from data.
+5. [docs/ADDING_A_MECHANIC.md](docs/ADDING_A_MECHANIC.md) — do this walkthrough; adding a
+   mechanic touches every layer and is the fastest way to *get* the architecture.
+
 ## Highlights
 
 - **Event-driven core.** No cross-system method calls. Three event domains
@@ -13,8 +31,9 @@ point for your own runner, or as a reference for decoupled, event-driven Unity d
   declarative auto-chaining and a single cross-domain bridge.
 - **Additive scene composition.** A persistent bootstrap scene loads UI and gameplay scenes
   additively; gameplay is split from visuals, audio, and environment.
-- **Data-driven track generation.** Track segments and per-level rulesets are authored in
-  JSON and selected at runtime by tag/difficulty. Includes an in-editor Track Level Editor.
+- **Data-driven track generation.** Track segments and per-level rulesets are authored as
+  ScriptableObject assets (edited in the Inspector) and selected at runtime by
+  tag/difficulty — no code changes needed to add a segment or a level.
 - **Full runner mechanics.** Turns, lane changes, jump, slide, dash, obstacles, coins,
   power-ups (speed, score multiplier, coin magnet, shield), countdown, and a level selector
   with unlock/best-score persistence.
@@ -39,7 +58,7 @@ point for your own runner, or as a reference for decoupled, event-driven Unity d
 |-----|------|
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Event domains, run sequence, and scene composition (with diagrams) |
 | [docs/EVENTS.md](docs/EVENTS.md) | Full event catalog: every event, value, auto-chain, and bridge mapping |
-| [docs/TRACKS.md](docs/TRACKS.md) | Track generation pipeline, JSON schema, and segment geometry |
+| [docs/TRACKS.md](docs/TRACKS.md) | Track generation pipeline, ScriptableObject data model, and segment geometry |
 | [docs/ADDING_A_MECHANIC.md](docs/ADDING_A_MECHANIC.md) | End-to-end walkthrough: adding a gameplay mechanic |
 | [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md) | Unity 6000.5 caveats (UIDocument/Panel Renderer, build order, JsonUtility) |
 | [CLAUDE.md](CLAUDE.md) | AI-assistant guide: conventions and the event-system rules |
@@ -48,10 +67,20 @@ point for your own runner, or as a reference for decoupled, event-driven Unity d
 
 ## Architecture
 
+### The one rule
+
+Systems never call each other. A system that wants something to happen **publishes an
+event**; systems that care **subscribe** and react. The jump button doesn't call the player
+controller — it publishes `UserJumpRequested`; the jump controller subscribes, does the
+jump, and publishes `JumpStarted`, which the animation and sound systems subscribe to in
+turn. No component holds a reference to a component in another system, so any system can be
+rewritten, replaced, or deleted without touching the others.
+
 ### Event domains
 
-All communication between systems goes through the `EventsPublisher` event bus. Each domain
-owns its own enum and singleton publisher:
+All communication between systems goes through the `EventsPublisher` event bus. Events are
+grouped into three **domains** — separate enums with separate publishers — so that input,
+gameplay, and application lifecycle stay independent of one another:
 
 | Domain | Enum | Responsibility |
 |--------|------|----------------|
@@ -95,9 +124,11 @@ Track generation is a three-stage, fully event-decoupled pipeline:
    (axis-aligned 90° turns), including "Either" T-junctions resolved by the player's choice.
 3. **Visuals** (`PrefabSpawnerAbstract` subclasses) — spawns and recycles track geometry.
 
-Segments live in `Assets/TempleRun/Resources/TrackSegments_Registry.json`; per-level rulesets
-live in `TrackLevel_*.json`. Author them with **`CrawfisSoftware > Track Level Editor`** or the
-`/generate-segments` skill.
+Segments and per-level rulesets are ScriptableObject assets in
+`Assets/TempleRun/Scriptables/Track/` (`TrackSegmentSO`, `TrackSegmentRegistrySO`,
+`TrackLevelSO`, `TrackLevelRegistrySO`). Edit them in the Inspector, create new ones from
+`Assets > Create > CrawfisSoftware > TempleRun`, or use the `/generate-segments` skill.
+See [docs/TRACKS.md](docs/TRACKS.md).
 
 ## Extending the Template
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ subscribing to named events.
 | [docs/EVENTS.md](docs/EVENTS.md) | Full event catalog: every event, value, auto-chain, and bridge mapping |
 | [docs/TRACKS.md](docs/TRACKS.md) | Track generation pipeline, ScriptableObject data model, and segment geometry |
 | [docs/ADDING_A_MECHANIC.md](docs/ADDING_A_MECHANIC.md) | End-to-end walkthrough: adding a gameplay mechanic |
+| [docs/STUDENT_TASKS.md](docs/STUDENT_TASKS.md) | Task catalog: 75+ scoped projects, by sub-specialty, to take the runner to a polished product |
 | [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md) | Unity 6000.5 caveats (UIDocument/Panel Renderer, build order, JsonUtility) |
 | [CLAUDE.md](CLAUDE.md) | AI-assistant guide: conventions and the event-system rules |
 | [docs/specs/](docs/specs/) | Design specs and migration plans for proposed changes |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ subscribing to named events.
 | [docs/EVENTS.md](docs/EVENTS.md) | Full event catalog: every event, value, auto-chain, and bridge mapping |
 | [docs/TRACKS.md](docs/TRACKS.md) | Track generation pipeline, ScriptableObject data model, and segment geometry |
 | [docs/ADDING_A_MECHANIC.md](docs/ADDING_A_MECHANIC.md) | End-to-end walkthrough: adding a gameplay mechanic |
-| [docs/STUDENT_TASKS.md](docs/STUDENT_TASKS.md) | Task catalog: 100 scoped projects, by sub-specialty, to take the runner to a polished product |
+| [docs/STUDENT_TASKS.md](docs/STUDENT_TASKS.md) | Task catalog: 109 scoped projects, by sub-specialty, to take the runner to a polished product |
 | [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md) | Unity 6000.5 caveats (UIDocument/Panel Renderer, build order, JsonUtility) |
 | [CLAUDE.md](CLAUDE.md) | AI-assistant guide: conventions and the event-system rules |
 | [docs/specs/](docs/specs/) | Design specs and migration plans for proposed changes |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ subscribing to named events.
 | [docs/EVENTS.md](docs/EVENTS.md) | Full event catalog: every event, value, auto-chain, and bridge mapping |
 | [docs/TRACKS.md](docs/TRACKS.md) | Track generation pipeline, ScriptableObject data model, and segment geometry |
 | [docs/ADDING_A_MECHANIC.md](docs/ADDING_A_MECHANIC.md) | End-to-end walkthrough: adding a gameplay mechanic |
-| [docs/STUDENT_TASKS.md](docs/STUDENT_TASKS.md) | Task catalog: 75+ scoped projects, by sub-specialty, to take the runner to a polished product |
+| [docs/STUDENT_TASKS.md](docs/STUDENT_TASKS.md) | Task catalog: 100 scoped projects, by sub-specialty, to take the runner to a polished product |
 | [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md) | Unity 6000.5 caveats (UIDocument/Panel Renderer, build order, JsonUtility) |
 | [CLAUDE.md](CLAUDE.md) | AI-assistant guide: conventions and the event-system rules |
 | [docs/specs/](docs/specs/) | Design specs and migration plans for proposed changes |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,58 @@ How the pieces fit together. For the concrete event lists see [EVENTS.md](EVENTS
 track system see [TRACKS.md](TRACKS.md); for the AI-assistant conventions see
 [../CLAUDE.md](../CLAUDE.md).
 
+## The big idea
+
+Most Unity tutorials wire systems together with direct references: the input script calls a
+method on the player, the player calls the score UI, the UI pokes the game manager. It works
+at small scale and then rots — every system knows about every other system, and no piece can
+change without breaking its neighbors.
+
+This template takes the opposite discipline to its logical end: **systems never reference
+each other at all.** The only way anything happens is that one component *publishes* a named
+event on a shared bus and other components *subscribe* to it. This is the classic
+**publish/subscribe** (observer) pattern, applied uniformly:
+
+```csharp
+// The slide input doesn't know a slide controller exists:
+EventsPublisherUserInitiated.Instance.PublishEvent(UserInitiatedEvents.UserSlideRequested, this, null);
+
+// The slide controller doesn't know what asked for the slide:
+EventsPublisherTempleRun.Instance.SubscribeToEvent(TempleRunEvents.SlideStarting, OnSlideStarting);
+```
+
+What that buys:
+
+- **Decoupling.** Publisher and subscriber compile independently; neither holds a reference
+  to the other. Swap the input system, the visuals, or the whole player and nothing else
+  notices.
+- **Extension without modification.** Adding "play a sound on jump" is a *new* subscriber to
+  `JumpStarted` — zero edits to the jump controller (the open/closed principle in practice).
+- **Observability.** Because everything is an event, turning on event logging shows the whole
+  game narrating itself, which makes debugging cross-system behavior far easier than stepping
+  through call stacks.
+
+The cost is indirection: you can't ctrl-click from cause to effect, and an event with no
+subscriber fails silently. The template mitigates that with strict naming conventions, a
+checked-in [event catalog](EVENTS.md), and audit tooling (`/audit-events`).
+
+## Design vocabulary
+
+Patterns you will recognize from a software-design course, and where each one lives here:
+
+| Pattern / principle | Where it shows up |
+|---------------------|-------------------|
+| Publish/subscribe (observer) | The entire event bus: `EventsPublisher*.PublishEvent` / `SubscribeToEvent` |
+| Singleton | The three publishers (`EventsPublisher*.Instance`), `Blackboard.Instance` — initialized first via `[DefaultExecutionOrder(-10000)]` |
+| Bridge (between subsystems) | `TempleRunGameFlowBridge` — the *single* sanctioned crossing between the gameplay and app-lifecycle domains |
+| Lifecycle as a naming state machine | Every action is a `Requested → *ing → *ed` event chain, with `*Failed` / `*Cancelled` off-ramps |
+| Declarative control flow | Auto-chains: dictionaries mapping event → next event (`*AutoEventFlow.cs`), instead of imperative sequencing code |
+| Data-driven design | Track segments/levels as ScriptableObjects ([TRACKS.md](TRACKS.md)); tuning configs per mechanic |
+| Separation of data, loading, and use | Authoring SOs → `TrackLibraryLoader` → runtime `TrackSegmentLibrary`; the authored asset is never mutated |
+| Blackboard | `Blackboard.Instance` — shared runtime gameplay state written and read via well-known properties |
+| Model/view separation | Gameplay logic scenes vs. visuals/audio scenes; visuals subscribe to logic events, never the reverse |
+| Object pooling / recycling | Track segments and spawned prefabs are recycled as the player advances |
+
 ## Event domains
 
 Every system communicates through a typed event bus. Each domain owns an enum and a singleton
@@ -107,6 +159,15 @@ manager class:
 > gameplay scenes being **last** in the Build Settings scene list, and the boot chain being
 > first. The entry scene must be build index 0. If you reorder Build Settings, re-check the
 > keep-index. See [KNOWN_ISSUES.md](KNOWN_ISSUES.md).
+
+## Track generation (summary)
+
+The endless track is produced by a three-stage pipeline whose stages communicate only through
+events — selection (`TrackManager` picks the next abstract segment from a data-driven
+library), geometry (`PathProvider` turns it into an Entrance → Pivot → Exit spline), and
+visuals (`PrefabSpawner*` builds and recycles the meshes, obstacles, and pickups). Segments
+and per-level rulesets are authored as ScriptableObjects and selected by tag/difficulty at
+runtime. Full detail, data model, and geometry math: [TRACKS.md](TRACKS.md).
 
 ## Where things live
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -86,10 +86,12 @@ GameConfigChangeRequested    → GameConfigApplying
 DifficultyChangeRequested    → DifficultyChanging
 PauseRequested               → Pausing → Paused
 ResumeRequested              → Resuming → Resumed
+LoadingScreenHidden          → GameplayReady             (boot complete)
 GameplayReady                → MainMenuShowRequested     (boot → menu)
 LevelSelected                → GameScenesLoadRequested   (level chosen → load)
 GameScenesLoaded             → GameStartRequested        (loaded → start)
 GameEnding                   → GameScenesUnloadRequested (death → unload)
+GameEnded                    → GameplayReady             (post-game → back to menu)
 ```
 *Commented out by default: the Save/Load chain and `QuitRequested → Quitting`.*
 

--- a/docs/STUDENT_TASKS.md
+++ b/docs/STUDENT_TASKS.md
@@ -1,13 +1,15 @@
 # Student Task Catalog: From Plain Runner to Polished Product
 
 The template is deliberately a *plain* runner — capsule player, primitive obstacles, flat
-track. That's the point: everything below is a well-scoped way to make it yours. Tasks are
-grouped by sub-specialty so a team can divide work along interests (gameplay code, tech art,
-audio, UI, systems design…). Effort tags are rough: **S** = a few days, **M** = a week or
-two, **L** = a multi-week centerpiece.
+track. That's the point: everything below is a well-scoped way to make it yours. **100
+tasks**, grouped by sub-specialty so a team can divide work along interests (gameplay code,
+tech art, audio, UI, systems design…). Effort tags are rough: **S** = a few days, **M** = a
+week or two, **L** = a multi-week centerpiece. Tasks are referenced as section-letter +
+number (e.g., A6, G3).
 
 Play Subway Surfers and Temple Run before choosing — most of these tasks are "the thing that
-makes those games feel finished."
+makes those games feel finished." (And see section O: the best task might come from
+dissecting a game *you* love.)
 
 **The one rule still applies.** Whatever you build, systems communicate through events
 (see [ARCHITECTURE.md](ARCHITECTURE.md)). Start every feature with the
@@ -33,7 +35,7 @@ makes those games feel finished."
 5. **Wall-run or grind rails (L).** Rails or wall segments the player can commit to as an
    alternate path over obstacles. Touches track data, player state, and visuals.
 6. **Climb & jump-up (M/L).** Tiles at different heights: low blocks you jump onto, tall
-   ones you climb (with an animation pause). Pairs with the voxel art task (G3).
+   ones you climb (with an animation pause). Pairs with the voxel tile art task (G3).
 7. **Moving obstacles (M).** Swinging blades, rolling boulders, trains sliding between
    lanes. Spawned per-segment like static obstacles but with scripted motion — keep motion
    logic separate from spawn logic.
@@ -51,184 +53,296 @@ makes those games feel finished."
 
 ## B. Track Generation & World Structure
 
-13. **Straight-tiles-only mode (M).** A subway-style level: no turns at all, lanes only —
-    author a `TrackLevelSO` whose pool is exclusively `Straight` segments, then rebalance
-    obstacles/coins so lane discipline carries the challenge.
-14. **New `ISegmentSelector`: distance-based difficulty ramp (M).** The selection policy is
-    a pluggable strategy (`Assets/TempleRun/Scripts/Track/Selection/`) with two existing
-    implementations (`WeightedDifficultySelector`, `AuthoredSequenceSelector`). Add one that
-    ramps target difficulty with `DistanceTravelled`.
-15. **New `ISegmentSelector`: wave pacing (M).** Encounter design — rest, build tension,
-    spike, rest. The selector alternates easy and hard pools on a distance rhythm.
-16. **New `IPathSegmentBuilder` (L).** Geometry is also a strategy
-    (`Assets/TempleRun/Scripts/Track/Geometry/`, `AxisAligned90Builder`, `ArcTurnBuilder`).
-    Add S-curves, gentle slopes, or banked turns. The hardest and most rewarding code task
-    in the track system.
-17. **Vertical track variation (L).** Make `LaneHeights` real: raised/lowered lanes and
-    segments at different elevations connected by ramps or the climb mechanic (A6).
-18. **Branch-and-rejoin routes (L).** Beyond the `Either` T-junction: parallel routes that
-    split and merge, one riskier but coin-rich.
-19. **Biome / theme system (M).** Drive prefab sets from `VisualTheme` and switch themes
-    every N segments — desert → temple → caves — including matched skybox and lighting.
-20. **Authored set-piece segments (S/M).** Hand-craft `Preset` spawn-slot segments — a coin
-    arc over a jump, an obstacle slalom — and weave them into levels via tags.
-21. **Expose segment `Connections` (M).** The runtime supports a which-segment-may-follow
-    graph; the authoring SOs don't expose it. Add it, plus editor validation for dead ends.
-22. **Endless scaling (S/M).** Interpolate speed and spawn rates continuously with distance
+1. **Straight-tiles-only mode (M).** A subway-style level: no turns at all, lanes only —
+   author a `TrackLevelSO` whose pool is exclusively `Straight` segments, then rebalance
+   obstacles/coins so lane discipline carries the challenge.
+2. **New `ISegmentSelector`: distance-based difficulty ramp (M).** The selection policy is
+   a pluggable strategy (`Assets/TempleRun/Scripts/Track/Selection/`) with two existing
+   implementations (`WeightedDifficultySelector`, `AuthoredSequenceSelector`). Add one that
+   ramps target difficulty with `DistanceTravelled`.
+3. **New `ISegmentSelector`: wave pacing (M).** Encounter design — rest, build tension,
+   spike, rest. The selector alternates easy and hard pools on a distance rhythm.
+4. **New `IPathSegmentBuilder` (L).** Geometry is also a strategy
+   (`Assets/TempleRun/Scripts/Track/Geometry/`, `AxisAligned90Builder`, `ArcTurnBuilder`).
+   Add S-curves, gentle slopes, or banked turns. The hardest and most rewarding code task
+   in the track system.
+5. **Vertical track variation (L).** Make `LaneHeights` real: raised/lowered lanes and
+   segments at different elevations connected by ramps or the climb mechanic (A6).
+6. **Branch-and-rejoin routes (L).** Beyond the `Either` T-junction: parallel routes that
+   split and merge, one riskier but coin-rich.
+7. **Biome / theme system (M).** Drive prefab sets from `VisualTheme` and switch themes
+   every N segments — desert → temple → caves — including matched skybox and lighting.
+8. **Authored set-piece segments (S/M).** Hand-craft `Preset` spawn-slot segments — a coin
+   arc over a jump, an obstacle slalom — and weave them into levels via tags.
+9. **Expose segment `Connections` (M).** The runtime supports a which-segment-may-follow
+   graph; the authoring SOs don't expose it. Add it, plus editor validation for dead ends.
+10. **Endless scaling (S/M).** Interpolate speed and spawn rates continuously with distance
     instead of stepping per level; find where it stops being fun.
 
 ## C. Characters & Animation
 
-23. **Animated character (L).** Replace the capsule with a rigged character: run cycle,
-    jump, slide, turn lean, death — all driven *only* by subscribing to gameplay events.
-    The flagship task for a character specialist.
-24. **Animation blending & sync (M).** Blend trees keyed to actual run speed; transition
-    polish so slides and jumps read at 60 km/h. Follows C23.
-25. **Character select & skins (M).** Multiple characters with distinct silhouettes;
-    selection UI; persistence of the chosen skin. Pairs with the shop (E5).
-26. **Ragdoll death (S/M).** Swap animator for physics on `PlayerDied`. Cheap drama.
-27. **Chaser NPC (L).** Temple Run's monkeys / Subway's inspector: a pursuer who closes in
-    when you stumble and catches you on the second mistake. This is really a *grace-period
-    system with a face* — design it as state driven by fail events.
-28. **Ambient NPCs (M).** Bystanders and critters along the track that react (dive away,
-    cheer). Spawn/recycle like scenery; zero gameplay coupling.
-29. **Companion pet (M).** Follows the player, scoops near-lane coins at intervals — a
-    lighter cousin of the coin magnet power-up.
+1. **Animated character (L).** Replace the capsule with a rigged character: run cycle,
+   jump, slide, turn lean, death — all driven *only* by subscribing to gameplay events.
+   The flagship task for a character specialist.
+2. **Animation blending & sync (M).** Blend trees keyed to actual run speed; transition
+   polish so slides and jumps read at 60 km/h. Follows C1.
+3. **Character select & skins (M).** Multiple characters with distinct silhouettes;
+   selection UI; persistence of the chosen skin. Pairs with the shop (E5).
+4. **Ragdoll death (S/M).** Swap animator for physics on `PlayerDied`. Cheap drama.
+5. **Chaser NPC (L).** Temple Run's monkeys / Subway's inspector: a pursuer who closes in
+   when you stumble and catches you on the second mistake. This is really a *grace-period
+   system with a face* — design it as state driven by fail events.
+6. **Ambient NPCs (M).** Bystanders and critters along the track that react (dive away,
+   cheer). Spawn/recycle like scenery; zero gameplay coupling.
+7. **Companion pet (M).** Follows the player, scoops near-lane coins at intervals — a
+   lighter cousin of the coin magnet power-up.
 
 ## D. Power-Ups & Collectables
 
-30. **New `IPowerUpEffect` strategies (S/M each).** Power-up behavior is a strategy
-    interface (`Assets/TempleRun/Scripts/PowerUps/IPowerUpEffect.cs`). Add: **jetpack**
-    (fly above the track collecting coin trails), **super sneakers** (jump height ×2 —
-    watch the obstacle tuning), **score frenzy** (×2 stacking with combo), **hoverboard**
-    (one free crash, then a cooldown).
-31. **Power-up upgrade tracks (M).** Spend coins to lengthen each power-up's duration —
-    the classic Subway Surfers meta-loop. Needs save persistence (L4).
-32. **Collectable hunts (S/M).** Collect the letters W-O-R-D across runs for a weekly
-    reward; drives return sessions.
-33. **Mystery box (S).** Rare pickup granting a random reward on the summary screen.
-34. **Coin choreography (S).** Author coin patterns with spawn slots: arcs over jumps,
-    trails threading the safe lane — coins as a *guidance system*, not just score.
-35. **Premium currency (S/M).** Rare gems alongside coins; separate wallet, separate sinks.
-    Foundation for the economy tasks (E5, E8).
+1. **New `IPowerUpEffect` strategies (S/M each).** Power-up behavior is a strategy
+   interface (`Assets/TempleRun/Scripts/PowerUps/IPowerUpEffect.cs`). Add: **jetpack**
+   (fly above the track collecting coin trails), **super sneakers** (jump height ×2 —
+   watch the obstacle tuning), **score frenzy** (×2 stacking with combo), **hoverboard**
+   (one free crash, then a cooldown).
+2. **Power-up upgrade tracks (M).** Spend coins to lengthen each power-up's duration —
+   the classic Subway Surfers meta-loop. Needs save persistence (L3).
+3. **Collectable hunts (S/M).** Collect the letters W-O-R-D across runs for a weekly
+   reward; drives return sessions.
+4. **Mystery box (S).** Rare pickup granting a random reward on the summary screen.
+5. **Coin choreography (S).** Author coin patterns with spawn slots: arcs over jumps,
+   trails threading the safe lane — coins as a *guidance system*, not just score.
+6. **Premium currency (S/M).** Rare gems alongside coins; separate wallet, separate sinks.
+   Foundation for the economy tasks (E5).
 
 ## E. Progression, Scores & Economy
 
-36. **Mission system (L).** Three concurrent objectives ("slide 20 times", "collect 500
-    coins in one run"); completing a set raises a permanent score multiplier. The single
-    strongest retention structure in the genre.
-37. **Player XP & unlock ladder (M).** Account level fed by run score; levels gate skins,
-    themes, power-ups.
-38. **Local achievements (M).** Event-driven achievement checks with a toast UI. (The
-    sibling RUGS template does this with Unity Gaming Services — compare approaches.)
-39. **Daily challenge & streaks (M).** A seeded daily level (same track for everyone — the
-    RNG is already injectable) plus streak rewards.
-40. **Shop & monetization design (L).** Spend coins/gems on skins, upgrades, consumables;
-    stub IAP behind an interface (no real store needed). A serious design exercise in
-    pricing a virtual economy — document your sink/faucet analysis.
-41. **Per-level stats & records (S).** Best distance, coins, longest combo per level;
-    surface them in the level selector.
-42. **Scoring rebalance (S/M).** Today score ≈ distance. Design a score model (distance +
-    coins × style multiplier), expose the weights in a tuning SO, and justify the choices.
-43. **Run summary screen (M).** Post-death breakdown with animated tallies — where score
-    design (E7) becomes visible to the player.
+1. **Mission system (L).** Three concurrent objectives ("slide 20 times", "collect 500
+   coins in one run"); completing a set raises a permanent score multiplier. The single
+   strongest retention structure in the genre.
+2. **Player XP & unlock ladder (M).** Account level fed by run score; levels gate skins,
+   themes, power-ups.
+3. **Local achievements (M).** Event-driven achievement checks with a toast UI. (The
+   sibling RUGS template does this with Unity Gaming Services — compare approaches.)
+4. **Daily challenge & streaks (M).** A seeded daily level (same track for everyone — the
+   RNG is already injectable) plus streak rewards.
+5. **Shop & monetization design (L).** Spend coins/gems on skins, upgrades, consumables;
+   stub IAP behind an interface (no real store needed). A serious design exercise in
+   pricing a virtual economy — document your sink/faucet analysis.
+6. **Per-level stats & records (S).** Best distance, coins, longest combo per level;
+   surface them in the level selector.
+7. **Scoring rebalance (S/M).** Today score ≈ distance. Design a score model (distance +
+   coins × style multiplier), expose the weights in a tuning SO, and justify the choices.
+8. **Run summary screen (M).** Post-death breakdown with animated tallies — where score
+   design (E7) becomes visible to the player.
+9. **Locked levels & unlock criteria (M).** The level selector already persists unlocks
+   and best scores (`LevelProgressManager`); make locking a real design surface: richer
+   unlock criteria (score threshold on the previous level, missions completed, stars
+   earned), and honest locked-state UI — padlock, progress toward unlocking, "reach
+   2000 m on Level 2 to unlock." Add 1–3 star ratings per level and star-gated content.
+10. **World-map level select (M/L).** Replace the level list with a map screen (in UI
+    Toolkit — see section I): a winding path of level nodes showing stars and locks, with
+    an animated reveal when a new level unlocks. The map *is* the progression display.
 
 ## F. VFX
 
-44. **Pickup & power-up particles (S/M).** Coin sparkles, power-up auras on the player,
-    collect bursts. All listeners to existing events — zero gameplay edits, which is the
-    point of the architecture.
-45. **Speed sensation pass (M).** FOV kick, subtle speed lines, camera shake on landings —
-    perceived speed is mostly VFX, not velocity.
-46. **Shader work (M/L).** Dissolve-out for despawning segments, a shimmering hologram
-    marker at `Either` junctions, scrolling energy on dash. Shader Graph territory.
-47. **Dash & slide trails (S).** Trail renderers toggled by `DashStarted`/`SlideStarted`.
-48. **Screen-space feedback (S).** Damage vignette on stumble, gold flash on milestone,
-    shield shimmer border while protected.
-49. **Environmental VFX (M).** Falling leaves, dust storms, fog volumes — per biome (B7).
+1. **Pickup & power-up particles (S/M).** Coin sparkles, power-up auras on the player,
+   collect bursts. All listeners to existing events — zero gameplay edits, which is the
+   point of the architecture.
+2. **Speed sensation pass (M).** FOV kick, subtle speed lines, camera shake on landings —
+   perceived speed is mostly VFX, not velocity.
+3. **Shader work (M/L).** Dissolve-out for despawning segments, a shimmering hologram
+   marker at `Either` junctions, scrolling energy on dash. Shader Graph territory.
+4. **Dash & slide trails (S).** Trail renderers toggled by `DashStarted`/`SlideStarted`.
+5. **Screen-space feedback (S).** Damage vignette on stumble, gold flash on milestone,
+   shield shimmer border while protected.
+6. **Environmental VFX (M).** Falling leaves, dust storms, fog volumes — per biome (B7).
 
 ## G. Art & Environment
 
-50. **Background & skybox art (M).** Layered parallax backdrops or authored skyboxes per
-    theme; the cheapest way to make the game look "real."
-51. **Themed obstacle & track art (M/L).** Replace primitives with modeled sets (temple
-    stone, subway props). Respect the spawner prefab contract (origin, trigger colliders).
-52. **Voxel tile sets with heights (L).** Voxel track tiles at multiple heights feeding the
-    climb/jump-up mechanic (A6) — art and gameplay co-designed. (A voxel spawner already
-    exists in `TrackVisuals` to build on.)
-53. **Trackside dressing with recycling (M).** Props along the track (pillars, banners,
-    wrecks) spawned per segment and pooled like everything else.
-54. **Decals & wear (S).** Track-surface variety — cracks, arrows before turns, skid marks.
+1. **Background & skybox art (M).** Layered parallax backdrops or authored skyboxes per
+   theme; the cheapest way to make the game look "real."
+2. **Themed obstacle & track art (M/L).** Replace primitives with modeled sets (temple
+   stone, subway props). Respect the spawner prefab contract (origin, trigger colliders).
+3. **Voxel tile sets with heights (L).** Voxel track tiles at multiple heights feeding the
+   climb/jump-up mechanic (A6) — art and gameplay co-designed. (A voxel spawner already
+   exists in `TrackVisuals` to build on.)
+4. **Trackside dressing with recycling (M).** Props along the track (pillars, banners,
+   wrecks) spawned per segment and pooled like everything else.
+5. **Decals & wear (S).** Track-surface variety — cracks, arrows before turns, skid marks.
 
 ## H. Lighting & Rendering
 
-55. **Time-of-day over a run (M).** Day → dusk → night as distance grows: gradient ambient,
-    rotating sun, emissive props waking up at night.
-56. **Lighting quality pass (M).** Light probes along the track, baked vs realtime
-    trade-offs with a moving world, URP volume tweaks per theme.
-57. **Post-processing profiles (S/M).** Bloom, color grading, vignette per biome; snappy
-    transition when themes change.
-58. **Rendering performance pass (M/L).** Profile, then fix: GPU instancing for tiles,
-    batching, overdraw. Produce a before/after frame-time report — the report is the
-    deliverable.
+1. **Time-of-day over a run (M).** Day → dusk → night as distance grows: gradient ambient,
+   rotating sun, emissive props waking up at night.
+2. **Lighting quality pass (M).** Light probes along the track, baked vs realtime
+   trade-offs with a moving world, URP volume tweaks per theme.
+3. **Post-processing profiles (S/M).** Bloom, color grading, vignette per biome; snappy
+   transition when themes change.
+4. **Rendering performance pass (M/L).** Profile, then fix: GPU instancing for tiles,
+   batching, overdraw. Produce a before/after frame-time report — the report is the
+   deliverable.
 
-## I. UI / UX
+## I. UI / UX — UI Toolkit Only
 
-59. **HUD polish (M).** Animated score ticker, coins that fly to the counter on pickup,
-    power-up duration rings.
-60. **Settings menu (M).** Audio sliders, quality presets, input rebinding — persisted.
-61. **First-run tutorial (M).** Contextual teach moments ("swipe up to jump" as the first
-    obstacle nears) driven by game events; skippable.
-62. **Game-over celebration (S/M).** New-best fanfare, progress bar to the next unlock —
-    make losing feel like progress.
-63. **Localization (M).** String tables for 2+ languages via Unity Localization; audit
-    every hard-coded string out of the UI.
-64. **Accessibility pass (M).** Colorblind-safe obstacle/pickup signaling, reduced-motion
-    toggle (kills camera shake/FOV kick), scalable HUD text, full input remapping.
+All UI in this template runs on **UI Toolkit** (UXML/USS rendered by `PanelRenderer`), and
+that is a hard constraint for every task below: **no uGUI, no Canvas, no TextMeshPro
+overlays.** Learning to ship polished runtime UI in UI Toolkit — the way current Unity
+expects — is part of the exercise. Read the PanelRenderer rules in
+[KNOWN_ISSUES.md](KNOWN_ISSUES.md) first (show/hide via `style.display`, cache roots from
+`UIReloaded`) or your panel will be mysteriously blank.
+
+1. **HUD polish (M).** Animated score ticker, coins that fly to the counter on pickup,
+   power-up duration rings.
+2. **Settings menu (M).** Audio sliders, quality presets, input rebinding — persisted.
+3. **First-run tutorial (M).** Contextual teach moments ("swipe up to jump" as the first
+   obstacle nears) driven by game events; skippable.
+4. **Game-over celebration (S/M).** New-best fanfare, progress bar to the next unlock —
+   make losing feel like progress.
+5. **Localization (M).** String tables for 2+ languages via Unity Localization; audit
+   every hard-coded string out of the UXML.
+6. **Accessibility pass (M).** Colorblind-safe obstacle/pickup signaling, reduced-motion
+   toggle (kills camera shake/FOV kick), scalable HUD text, full input remapping.
+7. **USS design system (M).** One shared stylesheet of USS variables — color roles,
+   spacing scale, type ramp, corner radii — and restyle every panel (menu, level select,
+   HUD, game over) to use it. Deliverable: a one-page style guide plus zero per-panel
+   hard-coded colors. This is the difference between "programmer UI" and a product.
+8. **Runtime theme switching (S/M).** Swap USS theme stylesheets at runtime — light/dark,
+   or a UI reskin per biome (B7) — by toggling theme classes or `ThemeStyleSheet`s on the
+   root. Prove it works mid-run.
+9. **Custom VisualElements (M).** Build reusable custom controls with UXML attributes: a
+   radial cooldown ring for power-ups, a segmented progress bar, an odometer-style score
+   counter. Package them so any panel can drop them in.
+10. **UI motion pass (M).** USS transitions and scheduler-driven animation for panel
+    slides, button press feedback, and staggered list reveals in the level selector.
+    Every animation must respect the reduced-motion toggle (I6).
+11. **HUD data binding (M/L).** The HUD currently updates from event handlers; explore UI
+    Toolkit's runtime data-binding to bind labels/bars to a view-model that the event
+    handlers update. Compare the two patterns and write up which you'd keep — that
+    write-up is course gold.
 
 ## J. Audio
 
-65. **Adaptive music (M/L).** Layered stems that build with speed/combo intensity; duck on
-    death; stinger on milestones. (The `GTMY.Audio` package is already a dependency.)
-66. **Full SFX pass (M).** Footsteps by surface, whoosh on near-miss, distinct pickup
-    sounds, UI clicks — every sound a subscriber to an existing event, none wired into
-    gameplay code.
-67. **Mixer architecture (S/M).** Music/SFX/UI buses, pause/death snapshots, ducking.
-68. **Spatial & environmental audio (M).** Passing obstacles pan and doppler; reverb zones
-    in tunnels (B9 pairs well).
+1. **Adaptive music (M/L).** Layered stems that build with speed/combo intensity; duck on
+   death; stinger on milestones. (The `GTMY.Audio` package is already a dependency.)
+2. **Full SFX pass (M).** Footsteps by surface, whoosh on near-miss, distinct pickup
+   sounds, UI clicks — every sound a subscriber to an existing event, none wired into
+   gameplay code.
+3. **Mixer architecture (S/M).** Music/SFX/UI buses, pause/death snapshots, ducking.
+4. **Spatial & environmental audio (M).** Passing obstacles pan and doppler; reverb zones
+   in tunnels or under overhangs (pairs with B7 theming).
 
 ## K. Input & Porting
 
-69. **Mobile port (L).** Touch swipe tuning (the swipe detector exists), safe-area UI,
-    a real performance budget on a mid-range phone. "It runs on my phone" is not the bar —
-    "60 fps on a 3-year-old phone" is.
-70. **Accelerometer lane steering (S/M).** `AccelerometerInputActions` exists — make tilt
-    control feel good (dead zone, sensitivity curve, calibration button).
-71. **Gamepad + haptics (S/M).** Full controller support with rumble on hits/landings.
-72. **WebGL build & publish (M).** Ship to itch.io: build size diet, loading screen,
-    browser input quirks. Publishing is its own skill; do it early, not last.
+1. **Mobile port (L).** Touch swipe tuning (the swipe detector exists), safe-area UI,
+   a real performance budget on a mid-range phone. "It runs on my phone" is not the bar —
+   "60 fps on a 3-year-old phone" is.
+2. **Accelerometer lane steering (S/M).** `AccelerometerInputActions` exists — make tilt
+   control feel good (dead zone, sensitivity curve, calibration button).
+3. **Gamepad + haptics (S/M).** Full controller support with rumble on hits/landings.
+4. **WebGL build & publish (M).** Ship to itch.io: build size diet, loading screen,
+   browser input quirks. Publishing is its own skill; do it early, not last.
 
 ## L. Architecture & Code (major changes)
 
-73. **Consolidate `AutoEventFlowBase` (S/M).** The documented starter refactor: four
-    dispatch classes re-implement the same `Enum.Parse` logic; unify them in the shared
-    base class. Teaches the event plumbing end to end.
-74. **Generalized object pooling (M).** One pooling service for obstacles, coins, VFX, and
-    tiles, replacing per-spawner recycling. Measure allocation before/after.
-75. **Save system (M).** A versioned profile (coins, unlocks, settings, stats) saved via
-    events (`SaveRequested`/`Saved` hooks already exist in `GameFlowEvents`), pluggable
-    backend (PlayerPrefs vs file).
-76. **Ghost replay (L).** Record the input/event stream of a run; replay it as a
-    translucent ghost racing alongside. The event architecture makes the recording half
-    almost free — the playback half is the project.
-77. **Play-mode test suite (M).** Because everything is events, you can drive the game
-    headlessly: publish inputs, assert state transitions, catch auto-chain regressions.
-    Build the harness and 10 meaningful tests.
-78. **In-game event console (S/M).** Debug overlay streaming the event log live (filter by
-    domain), plus a "publish arbitrary event" panel. Every other team will thank you.
-79. **Difficulty director (L).** Replace static difficulty with a director that watches
-    player performance (deaths, near-misses, combo health) and adjusts spawn intensity —
-    rubber-banding done honestly. Combines B2, B10, and E7 thinking.
+1. **Consolidate `AutoEventFlowBase` (S/M).** The documented starter refactor: four
+   dispatch classes re-implement the same `Enum.Parse` logic; unify them in the shared
+   base class. Teaches the event plumbing end to end.
+2. **Generalized object pooling (M).** One pooling service for obstacles, coins, VFX, and
+   tiles, replacing per-spawner recycling. Measure allocation before/after.
+3. **Save system (M).** A versioned profile (coins, unlocks, settings, stats) saved via
+   events (`SaveRequested`/`Saved` hooks already exist in `GameFlowEvents`), pluggable
+   backend (PlayerPrefs vs file).
+4. **Ghost replay (L).** Record the input/event stream of a run; replay it as a
+   translucent ghost racing alongside. The event architecture makes the recording half
+   almost free — the playback half is the project.
+5. **Play-mode test suite (M).** Because everything is events, you can drive the game
+   headlessly: publish inputs, assert state transitions, catch auto-chain regressions.
+   Build the harness and 10 meaningful tests.
+6. **In-game event console (S/M).** Debug overlay streaming the event log live (filter by
+   domain), plus a "publish arbitrary event" panel. Every other team will thank you.
+7. **Difficulty director (L).** Replace static difficulty with a director that watches
+   player performance (deaths, near-misses, combo health) and adjusts spawn intensity —
+   rubber-banding done honestly. Combines B3, B10, and E7 thinking.
+
+## M. Genre Pivot: Runner → Explorer
+
+The runner formula is constant forward speed on a narrow path. Loosen either constraint and
+the game changes genre: wide spaces to roam, movement the player owns, and reasons to look
+around instead of ahead. This is the biggest design swing in the catalog — treat M1–M3 as
+the foundation and the rest as what you build on it. The track *generation* pipeline
+survives the pivot; what changes is how the player inhabits it.
+
+1. **Very wide paths (M/L).** Segments 10–20 lanes wide (or lane-free): grow `LaneCount` /
+   `LaneWidth` and replace discrete lane-hopping with continuous lateral steering. Audit
+   everything that assumes "a lane" — spawn slots, obstacle placement, coin lines.
+2. **Player-controlled forward movement (M/L).** Throttle, brake, even stop — forward
+   speed becomes an input, not a constant. `DistanceTracker` and everything derived from
+   distance (spawning, difficulty, turn windows) must tolerate a player who lingers.
+   Suddenly obstacles are things to *study*, not just dodge.
+3. **Explorer camera & controls (M/L).** A third-person controller within the generated
+   world: camera orbit, look-around, over-the-shoulder framing. Combined with M1–M2 you
+   have a walkable PCG environment.
+4. **Points of interest & secrets (M).** Side alcoves, breakable walls, hidden collectable
+   caches, risky detours — author them as `Preset` spawn-slot set pieces (B8) placed off
+   the main line, discovered rather than survived.
+5. **Objectives over distance (M/L).** Replace "run far" scoring with explore-to-find
+   goals: locate three relics, light every beacon, map N% of the level. Requires a quest
+   state system (event-driven, naturally) and a new win/lose definition.
+6. **Minimap & compass (M).** A UI Toolkit minimap drawn from the generated segment graph,
+   with fog-of-war for unvisited branches. Pairs with I9 (custom VisualElements).
+7. **Backtracking (L).** Let the player turn around. This breaks the deepest assumption in
+   the template — segments despawn behind you — so it's really a segment-lifecycle
+   redesign: keep-alive windows, re-entry events, memory budgeting. A great systems
+   deep-dive for a strong programmer.
+
+## N. Multiplayer
+
+Two tracks: couch multiplayer here, networked multiplayer in the RUGS sibling. Fair
+warning about the architecture: `UserInitiatedEvents` already carry a `PlayerNumber`
+payload, but `Blackboard` and most gameplay state are singletons that assume one player —
+**making player state per-player instead of global is the real work**, and it's exactly the
+kind of refactor the event architecture makes tractable.
+
+1. **Split-screen foundation: two players (L).** Unity Input System device pairing (one
+   gamepad each, or keyboard halves), per-player input streams, per-player state
+   (position, lives, score), and two cameras rendering side-by-side viewports into the
+   same generated track.
+2. **2–4 player couch race (L).** Builds on N1: a shared seeded track (the RNG is
+   injectable, so every player sees the identical level), 2×2 viewports for four players,
+   race rules — last-alive wins, or furthest distance when time expires — and a proper
+   winner screen.
+3. **Saboteur party mode (M/L).** Asymmetric couch play: one player runs while another
+   spends a resource budget to drop obstacles and trigger hazards ahead of them from a
+   top-down view. Swap seats each round. Cheap to build once N1 exists, and reliably the
+   most-laughed-at demo.
+4. **Networked multiplayer via RUGS (L).** In the RunnerUGSTemplate sibling: UGS Lobby +
+   Relay + Netcode for GameObjects. Keep it honest for a semester: same seeded track on
+   every client, replicate only each player's inputs/position/state, render remote players
+   as runners in your world. Start with two players before dreaming bigger.
+5. **Async ghost racing (M/L).** The networked feel without netcode: upload a recorded run
+   (L4) to UGS Cloud Save keyed by the leaderboard entry, download a friend's ghost, and
+   race it live. Often *more* fun than real-time for a runner — and it ships.
+
+## O. Dissect a Game You Love
+
+The catalog above is not a menu you're limited to — it's a pattern to imitate. The most
+valuable thing you can learn from this template is how to look at *any* game mechanic and
+see the events, states, and data underneath it.
+
+1. **The dissection exercise (S design + build varies).** Pick one element from a game you
+   play or a game you want to make — Subway Surfers' hoverboard save, Crossy Road's
+   unlock-toy machine, Vampire Survivors' level-up choices, Mario Kart's rubber-band
+   items, Alto's one-button flow, Fall Guys' round structure. Write a 1–2 page teardown:
+   What states does it have? What triggers transitions? What data drives it? Why does it
+   feel good? Then map it onto this template — which domain owns it, what events it
+   publishes/subscribes, what ScriptableObject data it needs, which existing interface
+   (`ISegmentSelector`, `IPowerUpEffect`, `IPathSegmentBuilder`) it plugs into — and build
+   the smallest version that actually plays. The teardown document is graded work, not
+   throwaway.
+2. **The pitch ritual (ongoing).** Make O1 a team habit: each milestone, every member
+   pitches one dissected element (teardown + event map + effort estimate); the team votes
+   one into the sprint. The winning pitch doc *is* the spec — and by semester's end you'll
+   have a backlog that looks like a real studio's.
 
 ---
 
@@ -243,4 +357,7 @@ makes those games feel finished."
 - **Art and audio tasks need no engine surgery.** Visual/audio scenes subscribe to events;
   that's why they're listed as independent tasks. If your art task seems to require editing
   a controller, re-read [ARCHITECTURE.md](ARCHITECTURE.md#the-big-idea).
+- **Big swings need a spine.** The explorer pivot (M) and multiplayer (N) are
+  team-defining choices, not side tasks — if you pick one, schedule its foundation tasks
+  first and let everyone else's work build on it.
 - **Run `/audit-events` before every merge.**

--- a/docs/STUDENT_TASKS.md
+++ b/docs/STUDENT_TASKS.md
@@ -1,0 +1,246 @@
+# Student Task Catalog: From Plain Runner to Polished Product
+
+The template is deliberately a *plain* runner — capsule player, primitive obstacles, flat
+track. That's the point: everything below is a well-scoped way to make it yours. Tasks are
+grouped by sub-specialty so a team can divide work along interests (gameplay code, tech art,
+audio, UI, systems design…). Effort tags are rough: **S** = a few days, **M** = a week or
+two, **L** = a multi-week centerpiece.
+
+Play Subway Surfers and Temple Run before choosing — most of these tasks are "the thing that
+makes those games feel finished."
+
+**The one rule still applies.** Whatever you build, systems communicate through events
+(see [ARCHITECTURE.md](ARCHITECTURE.md)). Start every feature with the
+[required skills workflow](../CLAUDE.md#required-skills-workflow): `/list-events` →
+`/add-event` → implement → `/audit-events`. The walkthrough in
+[ADDING_A_MECHANIC.md](ADDING_A_MECHANIC.md) is the recipe.
+
+---
+
+## A. Core Gameplay & Feel
+
+1. **Collision-driven turn failure (S/M).** Replace the distance-window turn-failure check
+   with physical trigger volumes on the corner walls — running into the wall publishes
+   `PlayerFailingAtTurn` instead of a distance comparison. Compare the two approaches: which
+   is more tunable? More honest to the player?
+2. **Trigger-based obstacle hits with a stumble state (M).** Distinct reactions: glancing
+   hit → stumble (slow down, grace period, drop coins); head-on → fail. Subway Surfers'
+   stumble is a big part of its fairness feel.
+3. **Roll mechanic (S).** The worked example in [ADDING_A_MECHANIC.md](ADDING_A_MECHANIC.md)
+   — a quick ground roll sibling to Jump/Slide/Dash. A good first task for any team member.
+4. **Double jump / air control (S).** Second jump mid-air; small lane-change authority while
+   airborne. Requires reasoning about the jump controller's state machine.
+5. **Wall-run or grind rails (L).** Rails or wall segments the player can commit to as an
+   alternate path over obstacles. Touches track data, player state, and visuals.
+6. **Climb & jump-up (M/L).** Tiles at different heights: low blocks you jump onto, tall
+   ones you climb (with an animation pause). Pairs with the voxel art task (G3).
+7. **Moving obstacles (M).** Swinging blades, rolling boulders, trains sliding between
+   lanes. Spawned per-segment like static obstacles but with scripted motion — keep motion
+   logic separate from spawn logic.
+8. **Near-miss detection (S/M).** Detect shaving past an obstacle within ε and reward it
+   (score bonus, sound, slow-mo flash). A small system with outsized feel impact.
+9. **Combo / momentum multiplier (M).** Chained actions (jump→slide→near-miss) build a
+   multiplier that decays when you play safe. Design the decay curve carefully.
+10. **Checkpoint milestones (S).** Every 500 m: fanfare, brief invulnerability, +bonus.
+11. **Revive / second chance (M).** On death, offer one revive per run (paid with a
+    currency or a cooldown). Requires a clean re-entry path through the event flow —
+    `PlayerReviveRequested/Reviving/Revived` already exist as hooks.
+12. **Tune the feel (M).** A pure design task: sweep speeds, jump arcs, lane-change
+    durations, camera FOV/follow-lag across difficulty levels; document before/after and
+    playtest results.
+
+## B. Track Generation & World Structure
+
+13. **Straight-tiles-only mode (M).** A subway-style level: no turns at all, lanes only —
+    author a `TrackLevelSO` whose pool is exclusively `Straight` segments, then rebalance
+    obstacles/coins so lane discipline carries the challenge.
+14. **New `ISegmentSelector`: distance-based difficulty ramp (M).** The selection policy is
+    a pluggable strategy (`Assets/TempleRun/Scripts/Track/Selection/`) with two existing
+    implementations (`WeightedDifficultySelector`, `AuthoredSequenceSelector`). Add one that
+    ramps target difficulty with `DistanceTravelled`.
+15. **New `ISegmentSelector`: wave pacing (M).** Encounter design — rest, build tension,
+    spike, rest. The selector alternates easy and hard pools on a distance rhythm.
+16. **New `IPathSegmentBuilder` (L).** Geometry is also a strategy
+    (`Assets/TempleRun/Scripts/Track/Geometry/`, `AxisAligned90Builder`, `ArcTurnBuilder`).
+    Add S-curves, gentle slopes, or banked turns. The hardest and most rewarding code task
+    in the track system.
+17. **Vertical track variation (L).** Make `LaneHeights` real: raised/lowered lanes and
+    segments at different elevations connected by ramps or the climb mechanic (A6).
+18. **Branch-and-rejoin routes (L).** Beyond the `Either` T-junction: parallel routes that
+    split and merge, one riskier but coin-rich.
+19. **Biome / theme system (M).** Drive prefab sets from `VisualTheme` and switch themes
+    every N segments — desert → temple → caves — including matched skybox and lighting.
+20. **Authored set-piece segments (S/M).** Hand-craft `Preset` spawn-slot segments — a coin
+    arc over a jump, an obstacle slalom — and weave them into levels via tags.
+21. **Expose segment `Connections` (M).** The runtime supports a which-segment-may-follow
+    graph; the authoring SOs don't expose it. Add it, plus editor validation for dead ends.
+22. **Endless scaling (S/M).** Interpolate speed and spawn rates continuously with distance
+    instead of stepping per level; find where it stops being fun.
+
+## C. Characters & Animation
+
+23. **Animated character (L).** Replace the capsule with a rigged character: run cycle,
+    jump, slide, turn lean, death — all driven *only* by subscribing to gameplay events.
+    The flagship task for a character specialist.
+24. **Animation blending & sync (M).** Blend trees keyed to actual run speed; transition
+    polish so slides and jumps read at 60 km/h. Follows C23.
+25. **Character select & skins (M).** Multiple characters with distinct silhouettes;
+    selection UI; persistence of the chosen skin. Pairs with the shop (E5).
+26. **Ragdoll death (S/M).** Swap animator for physics on `PlayerDied`. Cheap drama.
+27. **Chaser NPC (L).** Temple Run's monkeys / Subway's inspector: a pursuer who closes in
+    when you stumble and catches you on the second mistake. This is really a *grace-period
+    system with a face* — design it as state driven by fail events.
+28. **Ambient NPCs (M).** Bystanders and critters along the track that react (dive away,
+    cheer). Spawn/recycle like scenery; zero gameplay coupling.
+29. **Companion pet (M).** Follows the player, scoops near-lane coins at intervals — a
+    lighter cousin of the coin magnet power-up.
+
+## D. Power-Ups & Collectables
+
+30. **New `IPowerUpEffect` strategies (S/M each).** Power-up behavior is a strategy
+    interface (`Assets/TempleRun/Scripts/PowerUps/IPowerUpEffect.cs`). Add: **jetpack**
+    (fly above the track collecting coin trails), **super sneakers** (jump height ×2 —
+    watch the obstacle tuning), **score frenzy** (×2 stacking with combo), **hoverboard**
+    (one free crash, then a cooldown).
+31. **Power-up upgrade tracks (M).** Spend coins to lengthen each power-up's duration —
+    the classic Subway Surfers meta-loop. Needs save persistence (L4).
+32. **Collectable hunts (S/M).** Collect the letters W-O-R-D across runs for a weekly
+    reward; drives return sessions.
+33. **Mystery box (S).** Rare pickup granting a random reward on the summary screen.
+34. **Coin choreography (S).** Author coin patterns with spawn slots: arcs over jumps,
+    trails threading the safe lane — coins as a *guidance system*, not just score.
+35. **Premium currency (S/M).** Rare gems alongside coins; separate wallet, separate sinks.
+    Foundation for the economy tasks (E5, E8).
+
+## E. Progression, Scores & Economy
+
+36. **Mission system (L).** Three concurrent objectives ("slide 20 times", "collect 500
+    coins in one run"); completing a set raises a permanent score multiplier. The single
+    strongest retention structure in the genre.
+37. **Player XP & unlock ladder (M).** Account level fed by run score; levels gate skins,
+    themes, power-ups.
+38. **Local achievements (M).** Event-driven achievement checks with a toast UI. (The
+    sibling RUGS template does this with Unity Gaming Services — compare approaches.)
+39. **Daily challenge & streaks (M).** A seeded daily level (same track for everyone — the
+    RNG is already injectable) plus streak rewards.
+40. **Shop & monetization design (L).** Spend coins/gems on skins, upgrades, consumables;
+    stub IAP behind an interface (no real store needed). A serious design exercise in
+    pricing a virtual economy — document your sink/faucet analysis.
+41. **Per-level stats & records (S).** Best distance, coins, longest combo per level;
+    surface them in the level selector.
+42. **Scoring rebalance (S/M).** Today score ≈ distance. Design a score model (distance +
+    coins × style multiplier), expose the weights in a tuning SO, and justify the choices.
+43. **Run summary screen (M).** Post-death breakdown with animated tallies — where score
+    design (E7) becomes visible to the player.
+
+## F. VFX
+
+44. **Pickup & power-up particles (S/M).** Coin sparkles, power-up auras on the player,
+    collect bursts. All listeners to existing events — zero gameplay edits, which is the
+    point of the architecture.
+45. **Speed sensation pass (M).** FOV kick, subtle speed lines, camera shake on landings —
+    perceived speed is mostly VFX, not velocity.
+46. **Shader work (M/L).** Dissolve-out for despawning segments, a shimmering hologram
+    marker at `Either` junctions, scrolling energy on dash. Shader Graph territory.
+47. **Dash & slide trails (S).** Trail renderers toggled by `DashStarted`/`SlideStarted`.
+48. **Screen-space feedback (S).** Damage vignette on stumble, gold flash on milestone,
+    shield shimmer border while protected.
+49. **Environmental VFX (M).** Falling leaves, dust storms, fog volumes — per biome (B7).
+
+## G. Art & Environment
+
+50. **Background & skybox art (M).** Layered parallax backdrops or authored skyboxes per
+    theme; the cheapest way to make the game look "real."
+51. **Themed obstacle & track art (M/L).** Replace primitives with modeled sets (temple
+    stone, subway props). Respect the spawner prefab contract (origin, trigger colliders).
+52. **Voxel tile sets with heights (L).** Voxel track tiles at multiple heights feeding the
+    climb/jump-up mechanic (A6) — art and gameplay co-designed. (A voxel spawner already
+    exists in `TrackVisuals` to build on.)
+53. **Trackside dressing with recycling (M).** Props along the track (pillars, banners,
+    wrecks) spawned per segment and pooled like everything else.
+54. **Decals & wear (S).** Track-surface variety — cracks, arrows before turns, skid marks.
+
+## H. Lighting & Rendering
+
+55. **Time-of-day over a run (M).** Day → dusk → night as distance grows: gradient ambient,
+    rotating sun, emissive props waking up at night.
+56. **Lighting quality pass (M).** Light probes along the track, baked vs realtime
+    trade-offs with a moving world, URP volume tweaks per theme.
+57. **Post-processing profiles (S/M).** Bloom, color grading, vignette per biome; snappy
+    transition when themes change.
+58. **Rendering performance pass (M/L).** Profile, then fix: GPU instancing for tiles,
+    batching, overdraw. Produce a before/after frame-time report — the report is the
+    deliverable.
+
+## I. UI / UX
+
+59. **HUD polish (M).** Animated score ticker, coins that fly to the counter on pickup,
+    power-up duration rings.
+60. **Settings menu (M).** Audio sliders, quality presets, input rebinding — persisted.
+61. **First-run tutorial (M).** Contextual teach moments ("swipe up to jump" as the first
+    obstacle nears) driven by game events; skippable.
+62. **Game-over celebration (S/M).** New-best fanfare, progress bar to the next unlock —
+    make losing feel like progress.
+63. **Localization (M).** String tables for 2+ languages via Unity Localization; audit
+    every hard-coded string out of the UI.
+64. **Accessibility pass (M).** Colorblind-safe obstacle/pickup signaling, reduced-motion
+    toggle (kills camera shake/FOV kick), scalable HUD text, full input remapping.
+
+## J. Audio
+
+65. **Adaptive music (M/L).** Layered stems that build with speed/combo intensity; duck on
+    death; stinger on milestones. (The `GTMY.Audio` package is already a dependency.)
+66. **Full SFX pass (M).** Footsteps by surface, whoosh on near-miss, distinct pickup
+    sounds, UI clicks — every sound a subscriber to an existing event, none wired into
+    gameplay code.
+67. **Mixer architecture (S/M).** Music/SFX/UI buses, pause/death snapshots, ducking.
+68. **Spatial & environmental audio (M).** Passing obstacles pan and doppler; reverb zones
+    in tunnels (B9 pairs well).
+
+## K. Input & Porting
+
+69. **Mobile port (L).** Touch swipe tuning (the swipe detector exists), safe-area UI,
+    a real performance budget on a mid-range phone. "It runs on my phone" is not the bar —
+    "60 fps on a 3-year-old phone" is.
+70. **Accelerometer lane steering (S/M).** `AccelerometerInputActions` exists — make tilt
+    control feel good (dead zone, sensitivity curve, calibration button).
+71. **Gamepad + haptics (S/M).** Full controller support with rumble on hits/landings.
+72. **WebGL build & publish (M).** Ship to itch.io: build size diet, loading screen,
+    browser input quirks. Publishing is its own skill; do it early, not last.
+
+## L. Architecture & Code (major changes)
+
+73. **Consolidate `AutoEventFlowBase` (S/M).** The documented starter refactor: four
+    dispatch classes re-implement the same `Enum.Parse` logic; unify them in the shared
+    base class. Teaches the event plumbing end to end.
+74. **Generalized object pooling (M).** One pooling service for obstacles, coins, VFX, and
+    tiles, replacing per-spawner recycling. Measure allocation before/after.
+75. **Save system (M).** A versioned profile (coins, unlocks, settings, stats) saved via
+    events (`SaveRequested`/`Saved` hooks already exist in `GameFlowEvents`), pluggable
+    backend (PlayerPrefs vs file).
+76. **Ghost replay (L).** Record the input/event stream of a run; replay it as a
+    translucent ghost racing alongside. The event architecture makes the recording half
+    almost free — the playback half is the project.
+77. **Play-mode test suite (M).** Because everything is events, you can drive the game
+    headlessly: publish inputs, assert state transitions, catch auto-chain regressions.
+    Build the harness and 10 meaningful tests.
+78. **In-game event console (S/M).** Debug overlay streaming the event log live (filter by
+    domain), plus a "publish arbitrary event" panel. Every other team will thank you.
+79. **Difficulty director (L).** Replace static difficulty with a director that watches
+    player performance (deaths, near-misses, combo health) and adjusts spawn intensity —
+    rubber-banding done honestly. Combines B2, B10, and E7 thinking.
+
+---
+
+## Choosing well
+
+- **Pick a vertical slice, not a layer.** "Chaser NPC + stumble + its audio/VFX" beats
+  "all the VFX in the game." Slices force the event-driven integration this template
+  exists to teach.
+- **Check the seams first.** If your task touches segment selection, geometry, or
+  power-ups, there is probably already an interface for it (`ISegmentSelector`,
+  `IPathSegmentBuilder`, `IPowerUpEffect`) — implement a strategy, don't fork the caller.
+- **Art and audio tasks need no engine surgery.** Visual/audio scenes subscribe to events;
+  that's why they're listed as independent tasks. If your art task seems to require editing
+  a controller, re-read [ARCHITECTURE.md](ARCHITECTURE.md#the-big-idea).
+- **Run `/audit-events` before every merge.**

--- a/docs/STUDENT_TASKS.md
+++ b/docs/STUDENT_TASKS.md
@@ -1,15 +1,20 @@
 # Student Task Catalog: From Plain Runner to Polished Product
 
 The template is deliberately a *plain* runner — capsule player, primitive obstacles, flat
-track. That's the point: everything below is a well-scoped way to make it yours. **100
+track. That's the point: everything below is a well-scoped way to make it yours. **109
 tasks**, grouped by sub-specialty so a team can divide work along interests (gameplay code,
 tech art, audio, UI, systems design…). Effort tags are rough: **S** = a few days, **M** = a
 week or two, **L** = a multi-week centerpiece. Tasks are referenced as section-letter +
 number (e.g., A6, G3).
 
 Play Subway Surfers and Temple Run before choosing — most of these tasks are "the thing that
-makes those games feel finished." (And see section O: the best task might come from
+makes those games feel finished." (And see section P: the best task might come from
 dissecting a game *you* love.)
+
+Tasks that need online services (networked multiplayer, cloud leaderboards, live tuning)
+build on the sibling **[RunnerUGSTemplate](https://github.com/crawfis/RunnerUGSTemplate)**
+(RUGS) — the same runner with Unity Gaming Services integrated as a fourth event domain.
+See sections N and O.
 
 **The one rule still applies.** Whatever you build, systems communicate through events
 (see [ARCHITECTURE.md](ARCHITECTURE.md)). Start every feature with the
@@ -297,8 +302,8 @@ survives the pivot; what changes is how the player inhabits it.
 
 ## N. Multiplayer
 
-Two tracks: couch multiplayer here, networked multiplayer in the RUGS sibling. Fair
-warning about the architecture: `UserInitiatedEvents` already carry a `PlayerNumber`
+Two tracks: couch multiplayer here, networked multiplayer in the RUGS sibling (whose other
+cloud services are covered in section O). Fair warning about the architecture: `UserInitiatedEvents` already carry a `PlayerNumber`
 payload, but `Blackboard` and most gameplay state are singletons that assume one player —
 **making player state per-player instead of global is the real work**, and it's exactly the
 kind of refactor the event architecture makes tractable.
@@ -323,7 +328,49 @@ kind of refactor the event architecture makes tractable.
    (L4) to UGS Cloud Save keyed by the leaderboard entry, download a friend's ghost, and
    race it live. Often *more* fun than real-time for a runner — and it ships.
 
-## O. Dissect a Game You Love
+## O. Live Services with UGS (in the RUGS sibling)
+
+These tasks live in the **[RunnerUGSTemplate](https://github.com/crawfis/RunnerUGSTemplate)**
+— the same runner with **Unity Gaming Services** integrated as a fourth event domain
+(`UGS_EventsEnum`, bridged to GameFlow by `UGSGameFlowBridge`, so cloud services never
+touch gameplay code directly). RUGS already ships working Authentication, Leaderboards,
+Achievements, and Remote Config; these tasks extend them into real live-ops features. Fair
+warning: UGS work has a setup tax (project linking, environments, deployments) — budget
+O1 before anything else.
+
+1. **Stand it up (S/M).** Clone RUGS, link your own UGS project, create environments,
+   deploy the config, and get the full loop running: sign in → run → score on the
+   leaderboard → achievement toast. Sounds trivial; teaches the entire cloud workflow and
+   is the prerequisite for everything below.
+2. **Leaderboard variants (M).** Beyond the daily-distance board: weekly and all-time
+   boards, per-level boards keyed to the level number, and a friends/bucket view. Design
+   which boards *mean* something — a board nobody can climb is worse than none.
+3. **Achievements that teach the game (M).** Replace the placeholder achievements with a
+   real set tied to catalog mechanics — near-misses (A8), combos (A9), missions (E1) — as
+   instant and progressive tiers. Good achievements are a curriculum for playing well.
+4. **Live tuning with Remote Config (M).** Move difficulty and economy knobs
+   (`DifficultyConfig` values, coin values, power-up durations) behind Remote Config so
+   you can retune the live game without a rebuild. Then run a real **A/B test**: two
+   scoring models (E7) served to different cohorts, compared on the leaderboard.
+5. **Seasonal event (M/L).** A limited-time challenge switched on by a Remote Config
+   feature flag: themed level, event currency, its own leaderboard, countdown UI. The
+   full live-ops loop in miniature — ship it, run it for two weeks, retire it.
+6. **Cloud Save profiles (M).** Sync the save system (L3) — coins, unlocks, stars,
+   settings — to UGS Cloud Save so a player's progress follows their sign-in across
+   devices. Handle the classic conflict: local progress vs. cloud progress, who wins?
+7. **Server-authoritative scores with Cloud Code (L).** Don't trust the client: submit
+   the run's stat block (distance, duration, coins, event counts) to a Cloud Code
+   endpoint that sanity-checks it — impossible speed, coins > spawned, duration mismatch
+   — before writing the leaderboard. A genuine introduction to anti-cheat thinking.
+8. **Economy service integration (M/L).** Back the shop (E5) with UGS Economy: server-side
+   currency balances, virtual purchases, an inventory of owned skins/upgrades. Pairs with
+   O7 — a server-trusted wallet is what makes the shop cheat-resistant.
+9. **Analytics-driven tuning (M).** Instrument the funnel with Unity Analytics custom
+   events — where players die (which segment ids), which power-ups get used, session
+   length — then present a tuning change justified by the data. The dashboard and the
+   argument are the deliverable.
+
+## P. Dissect a Game You Love
 
 The catalog above is not a menu you're limited to — it's a pattern to imitate. The most
 valuable thing you can learn from this template is how to look at *any* game mechanic and
@@ -339,7 +386,7 @@ see the events, states, and data underneath it.
    (`ISegmentSelector`, `IPowerUpEffect`, `IPathSegmentBuilder`) it plugs into — and build
    the smallest version that actually plays. The teardown document is graded work, not
    throwaway.
-2. **The pitch ritual (ongoing).** Make O1 a team habit: each milestone, every member
+2. **The pitch ritual (ongoing).** Make P1 a team habit: each milestone, every member
    pitches one dissected element (teardown + event map + effort estimate); the team votes
    one into the sprint. The winning pitch doc *is* the spec — and by semester's end you'll
    have a backlog that looks like a real studio's.


### PR DESCRIPTION
## Summary

Documentation-only. Four commits:

- **Doc refresh for a senior-undergraduate audience** — README gains audience framing, a suggested reading order, a plain-language statement of the no-direct-calls rule, and loses its stale JSON/Track Level Editor references (track data is ScriptableObjects). ARCHITECTURE.md gains "The big idea" (pub/sub rationale, costs and mitigations) and a design-vocabulary table mapping classroom patterns to their locations in the codebase. AGENTS.md gains a documentation map with audience register and update triggers. CLAUDE.md un-flags `/generate-segments` as legacy (it targets SOs now). EVENTS.md gains two GameFlow auto-chains that were missing vs. source (`LoadingScreenHidden -> GameplayReady`, `GameEnded -> GameplayReady`).
- **Student task catalog** (`docs/STUDENT_TASKS.md`) — scoped polish projects grouped by sub-specialty, tied to the template's real extension seams (`ISegmentSelector`, `IPathSegmentBuilder`, `IPowerUpEffect`, event-driven visual/audio layers).
- **Catalog expansion** — UI Toolkit-only styling tasks, locked levels + world-map level select, a runner-to-explorer genre-pivot section, couch split-screen and networked multiplayer sections, and the "dissect a game you love" exercise.
- **UGS live-services section** — nine tasks building on the RunnerUGSTemplate sibling (leaderboard variants, Remote Config live tuning/AB tests, seasonal events, Cloud Save, Cloud Code anti-cheat, Economy, analytics). Catalog totals 109 tasks.

The matching stale-doc fixes for RUGS are in a companion PR on crawfis/RunnerUGSTemplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWWo536vAkQ7xvCiqUqtH1